### PR TITLE
CP-16626 Move repo to http://github.com/xapi-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- vim: set ts=4 sw=4 et: -->
 
-[![Build Status](https://travis-ci.org/lindig/luna-rossa.svg?branch=master)](https://travis-ci.org/lindig/luna-rossa)
+[![Build Status](https://travis-ci.org/xapi-project/luna-rossa.svg?branch=master)](https://travis-ci.org/xapi-project/luna-rossa)
 
 # Luna Rossa - Testing Xen Server
 
@@ -39,7 +39,7 @@ essential for building Luna Rossa. Luna Rossa hasn't been released as an
 offical Opam package but it is easy to install it by pinning the source
 code repository:
 
-    opam pin add luna-rossa https://github.com/lindig/luna-rossa.git
+    opam pin add luna-rossa https://github.com/xapi-project/luna-rossa.git
 
 This installs the `lunarossa` binary and the `librossa` library package
 that becomes available for other code to use.  You can also look at the

--- a/_tags
+++ b/_tags
@@ -1,2 +1,8 @@
+# START_COVERAGE
+# coverage analysis with bisect_ppx
+# compile and link with package bisect_ppx
+<**/*.ml{,i,y}>: pkg_bisect_ppx
+<**/*.native>:   pkg_bisect_ppx
+# END_COVERAGE
 # OASIS_START
 # OASIS_STOP

--- a/opam/opam
+++ b/opam/opam
@@ -3,10 +3,10 @@ name: "luna-rossa"
 version: "0.3"
 maintainer: "Christian Lindig <christian.lindig@citrix.com>"
 authors: "Christian Lindig <christian.lindig@citrix.com>"
-homepage: "https://github.com/lindig/luna-rossa"
-bug-reports: "https://github.com/lindig/luna-rossa"
+homepage: "https://github.com/xapi-project/luna-rossa"
+bug-reports: "https://github.com/xapi-project/luna-rossa"
 license: "MIT"
-dev-repo: "https://github.com/lindig/luna-rossa"
+dev-repo: "https://github.com/xapi-project/luna-rossa"
 build: [
   ["oasis" "setup" "-setup-update" "dynamic"]
   ["./configure" "--prefix" prefix]

--- a/opam/opam
+++ b/opam/opam
@@ -13,7 +13,7 @@ build: [
   [make]
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "librossa"]
+remove: ["ocamlfind" "remove" "luna-rossa"]
 depends: [
   "ocamlfind" {build}
   "oasis" {build & >= "0.4"}


### PR DESCRIPTION
This repo is now owned by http://github.com/xapi-project. As part of the
move, some URLs needed to be changed to point to the new home.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>